### PR TITLE
Add link to the main SIG Multicluster page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You can reach the maintainers of this project at:
 
 - [Slack](https://kubernetes.slack.com/messages/sig-multicluster)
 - [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster)
+- [SIG Multicluster](https://github.com/kubernetes/community/blob/master/sig-multicluster/README.md)
 
 ### Code of conduct
 


### PR DESCRIPTION
This is particularly useful for reaching the weekly meeting Zoom link, etc.