### PR TITLE
Bump golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
       - uses: actions/setup-go@v3
       - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           # the version of golangci-lint.
-          version: v1.45.2
+          version: v1.58.0
 
           # show only new issues if it's a pull request.
           only-new-issues: false


### PR DESCRIPTION
It avoids the issue of golangci-lint that `panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt`.