### PR TITLE
Introduce dependabot to manage dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# This YAML configuration file is used to enable Dependabot for automated dependency management.
+# Dependabot helps keep the project's dependencies up-to-date by automatically creating pull requests
+# for outdated dependencies based on the version constraints defined in your project.
+# For more information and customization options, please refer to the Dependabot documentation:
+# Documentation: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically
+# Configuration options: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    # Check for updates to GitHub Actions every week
+    interval: "weekly"
+
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
Some of the actions have been deprecated and warnings raised like:
```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-go@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```
For more examples, please refer to https://github.com/RainbowMango/work-api/actions/runs/10570623576.

This PR introduced dependabot to bump GitHub Actions automatically, this practice works well at [the Karmada project](https://github.com/karmada-io/karmada/blob/master/.github/dependabot.yml).