### PR TITLE
Bump golangci/golangci-lint-action from 7 to 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         with:
           go-version: 1.23.7
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           # the version of golangci-lint.
-          version: v2.0.1
+          version: v2.1.6
 
           # show only new issues if it's a pull request.
           only-new-issues: false


### PR DESCRIPTION
substitution of #53, because golangci/golangci-lint-action@8 requires golangci-lint version >= v2.1.0.