### PR TITLE
ci: upgrade and pin GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: 1.25.8
+          cache-dependency-path: go.sum
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           # the version of golangci-lint.
           version: v2.8.0
@@ -31,14 +32,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           path: go/src/sigs.k8s.io/work-api
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: 1.25.8
+          cache-dependency-path: go/src/sigs.k8s.io/work-api/go.sum
       - name: verify
         run: hack/verify-all.sh -v
         env:
@@ -49,14 +51,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           path: go/src/sigs.k8s.io/work-api
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: 1.25.8
+          cache-dependency-path: go/src/sigs.k8s.io/work-api/go.sum
       - name: make test
         run: make test
         env:
@@ -66,22 +69,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
           path: go/src/sigs.k8s.io/work-api
       - name: install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: 1.25.8
+          cache-dependency-path: go/src/sigs.k8s.io/work-api/go.sum
       - name: images
         run: make docker-build
         env:
           GOPATH: '/home/runner/work/work-api/work-api/go'
       - name: setup kind
-        uses: engineerd/setup-kind@v0.6.2
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
-          version: v0.11.1
+          version: v0.32.0
+          node_image: kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95
+          cluster_name: kind
+          wait: 300s
+          kubectl_version: v1.35.0
       - name: Load image on the nodes of the cluster
         run: |
           kind load docker-image --name=kind work-api-controller:latest


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The Kubernetes GitHub Actions policy requires actions to be pinned to full
40-character commit SHAs. The current tag-based references, including the
changes proposed by #70 and #71, are rejected before the workflow steps can
run.

This PR upgrades every action in the CI workflow to its latest stable release
and pins the exact release commit, while retaining `# vX.Y.Z` comments for
Dependabot and reviewers:

- actions/checkout v7.0.1
- actions/setup-go v7.0.0
- golangci/golangci-lint-action v9.3.0
- helm/kind-action v1.14.0

`engineerd/setup-kind` is replaced rather than pinned in place because its
`v0.6.2` tag and same-named branch point to different commits. The tag commit
does not contain the action's built `dist/main/index.js`; pinning that official
tag commit by SHA was tested in [fork CI run 29794417222] and failed before
kind cluster creation. The branch commit contains the built files, but pinning
a different, non-tag commit behind the same version name would leave the action
provenance ambiguous. `helm/kind-action` provides a maintained, release-tagged
replacement with its built action entry points committed.

The replacement action cannot install the previous kind v0.11.1 release
because that legacy release uses a checksum asset format it cannot validate,
as shown by [fork CI run 29795085094]. Kind is therefore upgraded to v0.32.0.
Since kind v0.32.0 defaults to Kubernetes v1.36.1, the workflow explicitly
pins the official Kubernetes v1.35.5 node image digest and kubectl v1.35.0 to
stay aligned with this repository's Kubernetes v0.35.x dependencies.

Setup-go cache dependency paths are also explicit for both the root and
GOPATH-style checkout locations, avoiding cache warnings and ensuring the
module cache is used.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

This supersedes the dependency changes in #70 and #71. The action SHAs were
resolved from exact release tags, including the commit beneath
golangci-lint-action's annotated tag. This follows the same
`uses: owner/action@<full-sha> # vX.Y.Z` convention used by Karmada.

Validation:

- `actionlint v1.7.12`
- full-SHA scan of all 10 `uses:` references
- `./hack/verify-all.sh -v`
- [fork CI run 29795409249]: lint, verify, unit test, image build, kind setup,
  image load, and e2e all passed at commit
  `1ab1c5ee6303aa06766073076d89612fa989b662`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

[fork CI run 29794417222]: https://github.com/ranxi2001/work-api/actions/runs/29794417222
[fork CI run 29795085094]: https://github.com/ranxi2001/work-api/actions/runs/29795085094
[fork CI run 29795409249]: https://github.com/ranxi2001/work-api/actions/runs/29795409249

