### PR TITLE
Use the Ginkgo-provided context in tests

### DIFF
--- a/pkg/controllers/apply_controller_test.go
+++ b/pkg/controllers/apply_controller_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Work Controller", func() {
 	const timeout = time.Second * 30
 	const interval = time.Second * 1
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx context.Context) {
 		workNamespace = "work-" + utilrand.String(5)
 		// Create namespace
 		ns := &corev1.Namespace{
@@ -45,17 +45,17 @@ var _ = Describe("Work Controller", func() {
 				Name: workNamespace,
 			},
 		}
-		_, err := k8sClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+		_, err := k8sClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx context.Context) {
 		// Add any teardown steps that needs to be executed after each test
-		err := k8sClient.CoreV1().Namespaces().Delete(context.Background(), workNamespace, metav1.DeleteOptions{})
+		err := k8sClient.CoreV1().Namespaces().Delete(ctx, workNamespace, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 	})
 	Context("Deploy manifests by work", func() {
-		It("Should have a configmap deployed correctly", func() {
+		It("Should have a configmap deployed correctly", func(ctx context.Context) {
 			cmName := "testcm"
 			cmNamespace := "default"
 			cm := &corev1.ConfigMap{
@@ -88,16 +88,16 @@ var _ = Describe("Work Controller", func() {
 				},
 			}
 
-			_, err := workClient.MulticlusterV1alpha1().Works(workNamespace).Create(context.Background(), work, metav1.CreateOptions{})
+			_, err := workClient.MulticlusterV1alpha1().Works(workNamespace).Create(ctx, work, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() error {
-				_, err := k8sClient.CoreV1().ConfigMaps(cmNamespace).Get(context.Background(), cmName, metav1.GetOptions{})
+				_, err := k8sClient.CoreV1().ConfigMaps(cmNamespace).Get(ctx, cmName, metav1.GetOptions{})
 				return err
 			}, timeout, interval).Should(Succeed())
 
 			Eventually(func() error {
-				resultWork, err := workClient.MulticlusterV1alpha1().Works(workNamespace).Get(context.Background(), work.Name, metav1.GetOptions{})
+				resultWork, err := workClient.MulticlusterV1alpha1().Works(workNamespace).Get(ctx, work.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}

--- a/tests/e2e/apply_test.go
+++ b/tests/e2e/apply_test.go
@@ -35,7 +35,7 @@ const (
 
 var _ = ginkgo.Describe("Apply Work", func() {
 	ginkgo.Context("Create a service and deployment", func() {
-		ginkgo.It("Should create work successfully", func() {
+		ginkgo.It("Should create work successfully", func(ctx context.Context) {
 			workNamespace = "default"
 
 			manifestFiles := []string{
@@ -68,21 +68,21 @@ var _ = ginkgo.Describe("Apply Work", func() {
 					})
 			}
 
-			_, err := hubWorkClient.MulticlusterV1alpha1().Works(workNamespace).Create(context.Background(), work, metav1.CreateOptions{})
+			_, err := hubWorkClient.MulticlusterV1alpha1().Works(workNamespace).Create(ctx, work, metav1.CreateOptions{})
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				_, err := spokeKubeClient.AppsV1().Deployments("default").Get(context.Background(), "test-nginx", metav1.GetOptions{})
+				_, err := spokeKubeClient.AppsV1().Deployments("default").Get(ctx, "test-nginx", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
 
-				_, err = spokeKubeClient.CoreV1().Services("default").Get(context.Background(), "test-nginx", metav1.GetOptions{})
+				_, err = spokeKubeClient.CoreV1().Services("default").Get(ctx, "test-nginx", metav1.GetOptions{})
 				return err
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				work, err := hubWorkClient.MulticlusterV1alpha1().Works(workNamespace).Get(context.Background(), "test-work", metav1.GetOptions{})
+				work, err := hubWorkClient.MulticlusterV1alpha1().Works(workNamespace).Get(ctx, "test-work", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This allows the tests to be canceled by Ginkgo.