### PR TITLE
Fix typo in e2e apply test error message

### DIFF
--- a/tests/e2e/apply_test.go
+++ b/tests/e2e/apply_test.go
@@ -88,7 +88,7 @@ var _ = ginkgo.Describe("Apply Work", func() {
 				}
 
 				if !meta.IsStatusConditionTrue(work.Status.Conditions, "Applied") {
-					return fmt.Errorf("Expect the applied contidion of the work is true")
+					return fmt.Errorf("Expect the applied condition of the work is true")
 				}
 
 				return nil


### PR DESCRIPTION
The apply e2e test's failure message read "Expect the applied contidion of the work is true". Fixed the typo to "condition".

Tested: go build and go vet are clean.

/kind cleanup
/sig multicluster